### PR TITLE
avoid explicitly close all data channels to prevent panics

### DIFF
--- a/disco/udp/stun.go
+++ b/disco/udp/stun.go
@@ -29,7 +29,6 @@ func (rt *stunRoundTripper) roundTrip(ctx context.Context, udpConn *net.UDPConn,
 	rt.init()
 	txID := stun.NewTxID()
 	ch := make(chan stunResponse)
-	defer close(ch)
 	rt.stunResponseMapMutex.Lock()
 	rt.stunResponseMap[string(txID[:])] = ch
 	rt.stunResponseMapMutex.Unlock()
@@ -87,7 +86,6 @@ func (c *stunRoundTripper) recvResponse(b []byte, peerAddr net.Addr) {
 			return
 		}
 		resp := stunResponse{txid: string(txid[:]), addr: addr}
-		defer func() { recover() }()
 		select {
 		case r <- resp:
 		default:

--- a/disco/ws/ws.go
+++ b/disco/ws/ws.go
@@ -100,9 +100,6 @@ func (c *WSConn) Write(p []byte) (n int, err error) {
 func (c *WSConn) Close() error {
 	c.closed.Store(true)
 	close(c.closedSig)
-	close(c.datagrams)
-	close(c.events)
-	close(c.connData)
 	close(c.connEOF)
 	if conn := c.rawConn.Load(); conn != nil {
 		_ = conn.WriteControl(websocket.CloseMessage,

--- a/netlink/addr_linux.go
+++ b/netlink/addr_linux.go
@@ -13,10 +13,10 @@ func AddrSubscribe(ctx context.Context, ch chan<- AddrUpdate) error {
 		return err
 	}
 	go func() {
-		defer close(ch)
 		for {
 			select {
 			case <-ctx.Done():
+				close(ch)
 				return
 			case e := <-rawChan:
 				ch <- AddrUpdate{

--- a/netlink/route_linux.go
+++ b/netlink/route_linux.go
@@ -18,10 +18,10 @@ func RouteSubscribe(ctx context.Context, ch chan<- RouteUpdate) error {
 		return err
 	}
 	go func() {
-		defer close(ch)
 		for {
 			select {
 			case <-ctx.Done():
+				close(ch)
 				return
 			case e := <-rawChan:
 				if e.Dst == nil || e.Gw == nil {

--- a/p2p/conn.go
+++ b/p2p/conn.go
@@ -145,9 +145,9 @@ func (c *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 func (c *PacketConn) Close() error {
 	c.closeOnce.Do(func() {
 		close(c.closeChan)
-		c.deadlineRead.Close()
-		c.udpConn.Close()
-		c.wsConn.Close()
+		_ = c.deadlineRead.Close()
+		_ = c.udpConn.Close()
+		_ = c.wsConn.Close()
 	})
 	return nil
 }


### PR DESCRIPTION
The solution is very simple and less intrusive.

Rule 1: Don't close all dataCh, let GC handle.
Rule 2: Make sure when ctx.Done() is triggered, all senders and receivers will finish. So the GC is happy to release the channel.

To figure out all ownership probems of send on closed channel of the project is impossible, it requires a clear design when write the first line code.

will fix #38